### PR TITLE
s/WebSerial/WebUSBSerial/g

### DIFF
--- a/demos/console/sketch/sketch.ino
+++ b/demos/console/sketch/sketch.ino
@@ -1,6 +1,6 @@
 #include <WebUSB.h>
 
-#define Serial WebSerial
+#define Serial WebUSBSerial
 
 const int ledPin = 13;
 

--- a/demos/rgb/sketch/sketch.ino
+++ b/demos/rgb/sketch/sketch.ino
@@ -1,6 +1,6 @@
 #include <WebUSB.h>
 
-#define Serial WebSerial
+#define Serial WebUSBSerial
 
 const int redPin = 9;
 const int greenPin = 10;

--- a/library/WebUSB/WebUSB.cpp
+++ b/library/WebUSB/WebUSB.cpp
@@ -18,7 +18,7 @@
 
 #include "WebUSB.h"
 
-WebUSB WebSerial;
+WebUSB WebUSBSerial;
 
 const uint8_t BOS_DESCRIPTOR[57] PROGMEM = {
 0x05,  // Length

--- a/library/WebUSB/WebUSB.h
+++ b/library/WebUSB/WebUSB.h
@@ -98,6 +98,6 @@ private:
 	int peek_buffer;
 };
 
-extern WebUSB WebSerial;
+extern WebUSB WebUSBSerial;
 
 #endif // WebUSB_h


### PR DESCRIPTION
I'd like to rename `WebSerial` to `WebUSBSerial` for two reasons:
1. There is already a [WebSerial Arduino library](https://github.com/codebendercc/WebSerial) that does something completely different.
2. Name is confusing especially with the "real" WebSerial API coming
3. I think it's better to be explicit about which Serial we're using instead of the `#define Serial WebSerial` which can be misleading for new comers.

Yeah. I'm not that good at counting...

R=@reillyeon
