### PR TITLE
Set |port| as null when disconnected

### DIFF
--- a/demos/rgb/rgb.js
+++ b/demos/rgb/rgb.js
@@ -47,6 +47,7 @@
         port.disconnect();
         connectButton.textContent = 'Connect';
         statusDisplay.textContent = '';
+        port = null;
       } else {
         serial.requestPort().then(selectedPort => {
           port = selectedPort;


### PR DESCRIPTION
This patch set |port| as null when "Disconnect" button is pressed.
