### PR TITLE
Microsoft OS 2.0 registry property descriptor

### DIFF
--- a/library/WebUSB/WebUSB.cpp
+++ b/library/WebUSB/WebUSB.cpp
@@ -16,6 +16,13 @@
    SOFTWARE.
  */
 
+#define MS_OS_20_SET_HEADER_DESCRIPTOR 0x00
+#define MS_OS_20_SUBSET_HEADER_CONFIGURATION 0x01
+#define MS_OS_20_SUBSET_HEADER_FUNCTION 0x02
+#define MS_OS_20_FEATURE_COMPATIBLE_ID 0x03
+#define MS_OS_20_FEATURE_REG_PROPERTY 0x04
+#define MS_OS_20_DESCRIPTOR_LENGTH 0xb2
+
 #include "WebUSB.h"
 
 const uint8_t BOS_DESCRIPTOR_PREFIX[] PROGMEM = {
@@ -46,7 +53,7 @@ const uint8_t BOS_DESCRIPTOR_SUFFIX[] PROGMEM {
 0xDF, 0x60, 0xDD, 0xD8, 0x89, 0x45, 0xC7, 0x4C,
 0x9C, 0xD2, 0x65, 0x9D, 0x9E, 0x64, 0x8A, 0x9F,  // MS OS 2.0 GUID
 0x00, 0x00, 0x03, 0x06,  // Windows version
-0x2e, 0x00,  // Descriptor set length
+MS_OS_20_DESCRIPTOR_LENGTH, 0x00,  // Descriptor set length
 0x02,  // Vendor request code
 0x00   // Alternate enumeration code
 };
@@ -54,33 +61,51 @@ const uint8_t BOS_DESCRIPTOR_SUFFIX[] PROGMEM {
 const uint8_t MS_OS_20_DESCRIPTOR_PREFIX[] PROGMEM = {
 // Microsoft OS 2.0 descriptor set header (table 10)
 0x0A, 0x00,  // Descriptor size (10 bytes)
-0x00, 0x00,  // MS OS 2.0 descriptor set header
+MS_OS_20_SET_HEADER_DESCRIPTOR, 0x00,  // MS OS 2.0 descriptor set header
 0x00, 0x00, 0x03, 0x06,  // Windows version (8.1) (0x06030000)
-0x2e, 0x00,  // Size, MS OS 2.0 descriptor set
+MS_OS_20_DESCRIPTOR_LENGTH, 0x00,  // Size, MS OS 2.0 descriptor set
 
 // Microsoft OS 2.0 configuration subset header
 0x08, 0x00,  // Descriptor size (8 bytes)
-0x01, 0x00,  // MS OS 2.0 configuration subset header
+ MS_OS_20_SUBSET_HEADER_CONFIGURATION, 0x00,  // MS OS 2.0 configuration subset header
 0x00,        // bConfigurationValue
 0x00,        // Reserved
-0x24, 0x00,  // Size, MS OS 2.0 configuration subset
+0xA8, 0x00,  // Size, MS OS 2.0 configuration subset
 
 // Microsoft OS 2.0 function subset header
 0x08, 0x00,  // Descriptor size (8 bytes)
-0x02, 0x00,  // MS OS 2.0 function subset header
+ MS_OS_20_SUBSET_HEADER_FUNCTION, 0x00,  // MS OS 2.0 function subset header
 };
 
 // First interface number (1 byte) sent here.
 
 const uint8_t MS_OS_20_DESCRIPTOR_SUFFIX[] PROGMEM = {
 0x00,        // Reserved
-0x1c, 0x00,  // Size, MS OS 2.0 function subset
+0xA0, 0x00,  // Size, MS OS 2.0 function subset
 
 // Microsoft OS 2.0 compatible ID descriptor (table 13)
 0x14, 0x00,  // wLength
-0x03, 0x00,  // MS_OS_20_FEATURE_COMPATIBLE_ID
+MS_OS_20_FEATURE_COMPATIBLE_ID, 0x00,  // MS_OS_20_FEATURE_COMPATIBLE_ID
 'W',  'I',  'N',  'U',  'S',  'B',  0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+
+const uint8_t MS_OS_20_CUSTOM_PROPERTY[] PROGMEM = {
+0x84, 0x00,   //wLength: 
+MS_OS_20_FEATURE_REG_PROPERTY, 0x00,   // wDescriptorType: MS_OS_20_FEATURE_REG_PROPERTY: 0x04 (Table 9)
+0x07, 0x00,   //wPropertyDataType: REG_MULTI_SZ (Table 15)
+0x2a, 0x00,   //wPropertyNameLength: 
+//bPropertyName: “DeviceInterfaceGUID”
+'D', 0x00, 'e', 0x00, 'v', 0x00, 'i', 0x00, 'c', 0x00, 'e', 0x00, 'I', 0x00, 'n', 0x00, 't', 0x00, 'e', 0x00, 
+'r', 0x00, 'f', 0x00, 'a', 0x00, 'c', 0x00, 'e', 0x00, 'G', 0x00, 'U', 0x00, 'I', 0x00, 'D', 0x00, 's', 0x00, 
+0x00, 0x00,
+0x50, 0x00,   // wPropertyDataLength
+//bPropertyData: “{975F44D9-0D08-43FD-8B3E-127CA8AFFF9D}”.
+'{', 0x00, '9', 0x00, '7', 0x00, '5', 0x00, 'F', 0x00, '4', 0x00, '4', 0x00, 'D', 0x00, '9', 0x00, '-', 0x00, 
+'0', 0x00, 'D', 0x00, '0', 0x00, '8', 0x00, '-', 0x00, '4', 0x00, '3', 0x00, 'F', 0x00, 'D', 0x00, '-', 0x00, 
+'8', 0x00, 'B', 0x00, '3', 0x00, 'E', 0x00, '-', 0x00, '1', 0x00, '2', 0x00, '7', 0x00, 'C', 0x00, 'A', 0x00, 
+'8', 0x00, 'A', 0x00, 'F', 0x00, 'F', 0x00, 'F', 0x00, '9', 0x00, 'D', 0x00, '}', 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
 typedef struct
@@ -168,7 +193,11 @@ bool WebUSB::VendorControlRequest(USBSetup& setup)
 				return false;
 			if (USB_SendControl(0, &pluggedInterface, 1) < 0)
 				return false;
-			return USB_SendControl(TRANSFER_PGM, &MS_OS_20_DESCRIPTOR_SUFFIX, sizeof(MS_OS_20_DESCRIPTOR_SUFFIX)) >= 0;
+			if (USB_SendControl(TRANSFER_PGM, &MS_OS_20_DESCRIPTOR_SUFFIX, sizeof(MS_OS_20_DESCRIPTOR_SUFFIX)) < 0)
+			        return false;
+			if (USB_SendControl(TRANSFER_PGM, &MS_OS_20_CUSTOM_PROPERTY, sizeof(MS_OS_20_CUSTOM_PROPERTY)) < 0)
+			        return false;
+			return true;
 		}
 	}
 	return false;


### PR DESCRIPTION
Per MS https://msdn.microsoft.com/en-
us/library/windows/hardware/hh450799(v=vs.85).aspx
device should create DeviceInterfaceGUIDs. It can be done by driver and,
in case of real PnP solution, device should expose MS "Microsoft OS 2.0
registry property descriptor". Such descriptor can insert any record
into Windows registry per device/configuration/interface. In our case it
will insert "DeviceInterfaceGUIDs" multi string property.

GUID is freshly generated and should be OK to use.