### PR TITLE
Remove support for the GET_ALLOWED_ORIGINS request

### DIFF
--- a/demos/console/sketch/sketch.ino
+++ b/demos/console/sketch/sketch.ino
@@ -1,13 +1,6 @@
 #include <WebUSB.h>
 
-const WebUSBURL URLS[] = {
-  { 1, "webusb.github.io/arduino/demos/" },
-  { 0, "localhost:8000" },
-};
-
-const uint8_t ALLOWED_ORIGINS[] = { 1, 2 };
-
-WebUSB WebUSBSerial(URLS, 2, 1, ALLOWED_ORIGINS, 2);
+WebUSB WebUSBSerial(1, "webusb.github.io/arduino/demos");
 
 #define Serial WebUSBSerial
 

--- a/demos/rgb/sketch/sketch.ino
+++ b/demos/rgb/sketch/sketch.ino
@@ -1,13 +1,6 @@
 #include <WebUSB.h>
 
-const WebUSBURL URLS[] = {
-  { 1, "webusb.github.io/arduino/demos/" },
-  { 0, "localhost:8000" },
-};
-
-const uint8_t ALLOWED_ORIGINS[] = { 1, 2 };
-
-WebUSB WebUSBSerial(URLS, 2, 1, ALLOWED_ORIGINS, 2);
+WebUSB WebUSBSerial(1, "webusb.github.io/arduino/demos");
 
 #define Serial WebUSBSerial
 

--- a/library/WebUSB/WebUSB.h
+++ b/library/WebUSB/WebUSB.h
@@ -30,7 +30,6 @@
 #endif
 
 #define USB_BOS_DESCRIPTOR_TYPE		15
-#define WEBUSB_REQUEST_GET_ALLOWED_ORIGINS		0x01
 #define WEBUSB_REQUEST_GET_URL			0x02
 
 #define MS_OS_20_REQUEST_DESCRIPTOR 0x07
@@ -42,17 +41,10 @@ typedef struct
 	EndpointDescriptor  out;
 } WebUSBDescriptor;
 
-typedef struct
-{
-  uint8_t scheme;
-  const char* url;
-} WebUSBURL;
-
 class WebUSB : public PluggableUSBModule, public Stream
 {
 public:
-	WebUSB(const WebUSBURL* urls, uint8_t numUrls, uint8_t landingPage,
-               const uint8_t* allowedOrigins, uint8_t numAllowedOrigins);
+	WebUSB(uint8_t landingPageScheme, const char* landingPageUrl);
 	void begin(unsigned long);
 	void begin(unsigned long, uint8_t);
 	void end(void);
@@ -107,11 +99,8 @@ private:
 	uint8_t protocol;
 	uint8_t idle;
 	int peek_buffer;
-	const WebUSBURL* urls;
-	uint8_t numUrls;
-	uint8_t landingPage;
-	const uint8_t* allowedOrigins;
-	uint8_t numAllowedOrigins;
+	uint8_t landingPageScheme;
+	const char* landingPageUrl;
 };
 
 #endif // WebUSB_h


### PR DESCRIPTION
The GET_ALLOWED_ORIGINS request is no longer part of the WebUSB specification (WICG/webusb@c964613). This patch removes support for this request from the WebUSB library.

Resolves issue #30.