### PR TITLE
Add initial support for Arduino SAMD boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ WebUSB requires an Arduino model that gives the sketch complete control over the
 
  * Arduino Leonardo
  * Arduino/Genuino Micro
+ * Arduino/Genuino Zero
+ * Arduino MKR1000
+ * Arduino MKRZero
+ * Arduino MKRFox1200
 
 These boards are both based on the ATmega32U4.
 

--- a/demos/serial.js
+++ b/demos/serial.js
@@ -44,6 +44,7 @@ var serial = {};
           }
         })
         .then(() => this.device_.claimInterface(2))
+        .then(() => this.device_.selectAlternateInterface(2, 0))
         .then(() => this.device_.controlTransferOut({
             'requestType': 'class',
             'recipient': 'interface',

--- a/demos/serial.js
+++ b/demos/serial.js
@@ -13,6 +13,10 @@ var serial = {};
     const filters = [
       { 'vendorId': 0x2341, 'productId': 0x8036 },
       { 'vendorId': 0x2341, 'productId': 0x8037 },
+      { 'vendorId': 0x2341, 'productId': 0x804d },
+      { 'vendorId': 0x2341, 'productId': 0x804e },
+      { 'vendorId': 0x2341, 'productId': 0x804f },
+      { 'vendorId': 0x2341, 'productId': 0x8050 },
     ];
     return navigator.usb.requestDevice({ 'filters': filters }).then(
       device => new serial.Port(device)

--- a/library/WebUSB/WebUSB.cpp
+++ b/library/WebUSB/WebUSB.cpp
@@ -157,7 +157,7 @@ bool WebUSB::VendorControlRequest(USBSetup& setup)
 	if (setup.bmRequestType == (REQUEST_DEVICETOHOST | REQUEST_VENDOR | REQUEST_DEVICE)) {
 		if (setup.bRequest == 0x01 && setup.wIndex == WEBUSB_REQUEST_GET_URL && landingPageUrl)
 		{
-                        if (setup.wValueL != 1)
+			if (setup.wValueL != 1)
 				return false;
 			uint8_t urlLength = strlen(landingPageUrl);
 			uint8_t descriptorLength = urlLength + 3;

--- a/library/WebUSB/WebUSB.cpp
+++ b/library/WebUSB/WebUSB.cpp
@@ -18,6 +18,29 @@
 
 #include "WebUSB.h"
 
+#ifdef ARDUINO_ARCH_SAMD
+
+#define USB_SendControl				USBDevice.sendControl
+#define USB_RecvControl				USBDevice.recvControl
+#define USB_Available				USBDevice.available
+#define USB_Recv					USBDevice.recv
+#define USB_Send					USBDevice.send
+#define USB_SendSpace(ep)			(EPX_SIZE - 1)
+#define USB_Flush					USBDevice.flush
+#define ATOMIC_BLOCK(arg)
+
+#define TRANSFER_PGM 0
+
+#define EP_TYPE_BULK_IN_WEBUSB		USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_IN(0);
+#define EP_TYPE_BULK_OUT_WEBUSB		USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_OUT(0);
+
+#else
+
+#define EP_TYPE_BULK_IN_WEBUSB		EP_TYPE_BULK_IN
+#define EP_TYPE_BULK_OUT_WEBUSB		EP_TYPE_BULK_OUT
+
+#endif
+
 const uint8_t BOS_DESCRIPTOR_PREFIX[] PROGMEM = {
 0x05,  // Length
 0x0F,  // Binary Object Store descriptor
@@ -85,11 +108,11 @@ const uint8_t MS_OS_20_DESCRIPTOR_SUFFIX[] PROGMEM = {
 
 typedef struct
 {
-	u32	dwDTERate;
-	u8	bCharFormat;
-	u8 	bParityType;
-	u8 	bDataBits;
-	u8	lineState;
+	uint32_t	dwDTERate;
+	uint8_t	bCharFormat;
+	uint8_t 	bParityType;
+	uint8_t 	bDataBits;
+	uint8_t	lineState;
 } LineInfo;
 
 static volatile LineInfo _usbLineInfo = { 57600, 0x00, 0x00, 0x00, 0x00 };
@@ -204,8 +227,8 @@ WebUSB::WebUSB(uint8_t landingPageScheme, const char* landingPageUrl)
 	  landingPageScheme(landingPageScheme), landingPageUrl(landingPageUrl)
 {
 	// one interface, 2 endpoints
-	epType[0] = EP_TYPE_BULK_OUT;
-	epType[1] = EP_TYPE_BULK_IN;
+	epType[0] = EP_TYPE_BULK_OUT_WEBUSB;
+	epType[1] = EP_TYPE_BULK_IN_WEBUSB;
 	PluggableUSB().plug(this);
 }
 

--- a/library/WebUSB/WebUSB.h
+++ b/library/WebUSB/WebUSB.h
@@ -21,9 +21,13 @@
 
 #include <stdint.h>
 #include <Arduino.h>
+#ifdef ARDUINO_ARCH_SAMD
+#include "USB/PluggableUSB.h"
+#else
 #include "PluggableUSB.h"
 #include <avr/wdt.h>
 #include <util/atomic.h>
+#endif
 
 #ifndef USBCON
 #error "WebUSB requires a board that supports USB client device mode."
@@ -94,7 +98,11 @@ protected:
 private:
 	bool VendorControlRequest(USBSetup& setup);
 
+#ifdef ARDUINO_ARCH_SAMD
+	uint32_t epType[2];
+#else
 	uint8_t epType[2];
+#endif
 	uint16_t descriptorSize;
 	uint8_t protocol;
 	uint8_t idle;

--- a/library/WebUSB/library.properties
+++ b/library/WebUSB/library.properties
@@ -6,4 +6,4 @@ sentence=Module for PluggableUSB infrastructure. Exposes an API for WebUSB API
 paragraph=
 category=Communication
 url=http://www.arduino.cc/en/Reference/HID
-architectures=avr
+architectures=avr,samd


### PR DESCRIPTION
These changes add WebUSB support the Arduino SAMD boards, including: 
 * [Zero](https://www.arduino.cc/en/Main/ArduinoBoardZero)
 * [MKR1000](https://www.arduino.cc/en/Main/ArduinoMKR1000)
 * [MKRZero](https://www.arduino.cc/en/Main/ArduinoBoardMKRZero)
 * [MKRFox1200](https://store.arduino.cc/homepage/arduino-mkrfox1200)

I've tested on my Mac so far, and everything looks good. However, the SAMD core is hard coded for USB 2.0 currently, so a bit more work is required to support Windows.

cc/ @facchinm 
