### PR TITLE
remove delay in WebUSB

### DIFF
--- a/library/WebUSB/WebUSB.cpp
+++ b/library/WebUSB/WebUSB.cpp
@@ -353,24 +353,21 @@ size_t WebUSB::write(const uint8_t *buffer, size_t size)
 // We add a short delay before returning to fix a bug observed by Federico
 // where the port is configured (lineState != 0) but not quite opened.
 WebUSB::operator bool() {
-	static bool result = false;
-	static uint8_t prevLineState = 0;
-	static unsigned long lineStateChangeMillis = 0;
 	if (_usbLineInfo.lineState > 0) {
-		if (!result){
-			if (prevLineState == 0) {
-				lineStateChangeMillis = millis();
-			}else{
-				if (millis()-lineStateChangeMillis>=10){
-					result = true;
+		if (!portOpenResult){
+			if (portOpenPrevLineState == 0) {
+				portOpenLineStateChangeMillis = millis();
+			} else {
+				if (millis()-portOpenLineStateChangeMillis>=10){
+					portOpenResult = true;
 				}
 			}
 		}	
-	}else{
-		result=false;
+	} else {
+		portOpenResult=false;
 	}
-	prevLineState = _usbLineInfo.lineState;
-	return result;
+	portOpenPrevLineState = _usbLineInfo.lineState;
+	return portOpenResult;
 }
 
 unsigned long WebUSB::baud() {

--- a/library/WebUSB/WebUSB.h
+++ b/library/WebUSB/WebUSB.h
@@ -135,6 +135,10 @@ private:
 	uint8_t landingPageScheme;
 	const char* landingPageUrl;
 	const char* shortName;
+	
+	bool portOpenResult;
+	uint8_t portOpenPrevLineState;
+	unsigned long portOpenLineStateChangeMillis;
 };
 
 #endif // WebUSB_h


### PR DESCRIPTION
This makes state polling non-blocking to fix https://github.com/webusb/arduino/issues/50

The original Arduino CDC code used a delay to avoid some issue at cost of blocking all other code. As a result, this caused a big issue if you want to know if computer connects Arduino while you do fast/complex tasks. 10 milliseconds delay will cause a lot of issues.

![original](https://user-images.githubusercontent.com/1385273/43912073-3a904d42-9bcf-11e8-85ca-602a1401bcae.png)

You can see the code in loop can run 100 times per second.

There was commit to fix the issue (although not merged) 

"Fixed slowdown with repeated CDC bool operator test" 
https://github.com/arduino/ArduinoCore-avr/commit/53944cf44418c8c19906794ef904ae8353a4cc2d

![majenkotech _fix](https://user-images.githubusercontent.com/1385273/43912123-60bf03f0-9bcf-11e8-99cb-8d57de631cc5.png)

There is only one delay when computer connects.

I tried to improve that commit and remove all delay. Now the code is no longer blocking.

![screen shot 2018-08-09 at 12 18 15 pm](https://user-images.githubusercontent.com/1385273/43912194-994a09ea-9bcf-11e8-810b-5cfd97da0ebd.png)

And it will not interfere with other code.


