### PR TITLE
Dynamically choose interface number

### DIFF
--- a/demos/serial.js
+++ b/demos/serial.js
@@ -1,10 +1,11 @@
 var serial = {};
-var interfaceNumber=2;		// original interface number of WebUSB Arduino demo
-var endpointIn=5;			// original in endpoint ID of WebUSB Arduino demo
-var endpointOut=4;			// original out endpoint ID of WebUSB Arduino demo
 
 (function() {
   'use strict';
+	
+  var interfaceNumber=2;		// original interface number of WebUSB Arduino demo
+  var endpointIn=5;				// original in endpoint ID of WebUSB Arduino demo
+  var endpointOut=4;			// original out endpoint ID of WebUSB Arduino demo
 
   serial.getPorts = function() {
     return navigator.usb.getDevices().then(devices => {
@@ -48,24 +49,15 @@ var endpointOut=4;			// original out endpoint ID of WebUSB Arduino demo
         })
 		.then(()=> {
 			this.device_.configuration.interfaces.forEach(function(element) {
-				var found=false;
-				console.log(element.interfaceNumber);
-				
 				element.alternates.forEach(function(elementalt) {
 					if (elementalt.interfaceClass==0xff) {
-						console.log("Found!");
-						console.log("interfaceClass=%s",elementalt.interfaceClass);
-						found=true;
 						interfaceNumber=element.interfaceNumber;
-						
 						elementalt.endpoints.forEach(function(elementendpoint) {
 							if (elementendpoint.direction=="out") {
 								endpointOut=elementendpoint.endpointNumber;
-								console.log("out endpoint ID=%s", endpointOut);
 							}
 							if (elementendpoint.direction=="in") {
 								endpointIn=elementendpoint.endpointNumber;
-								console.log("in endpoint ID=%s", endpointIn);
 							}
 						})
 					}

--- a/demos/serial.js
+++ b/demos/serial.js
@@ -2,12 +2,7 @@ var serial = {};
 
 (function() {
   'use strict';
-	
-	/*
-  var interfaceNumber=2;		// original interface number of WebUSB Arduino demo
-  var endpointIn=5;				// original in endpoint ID of WebUSB Arduino demo
-  var endpointOut=4;			// original out endpoint ID of WebUSB Arduino demo
-	*/
+
   serial.getPorts = function() {
     return navigator.usb.getDevices().then(devices => {
       return devices.map(device => new serial.Port(device));
@@ -30,10 +25,9 @@ var serial = {};
 
   serial.Port = function(device) {
     this.device_ = device;
-	this.interfaceNumber_ =2;		// original interface number of WebUSB Arduino demo
-	this.endpointIn_ =5;			// original in endpoint ID of WebUSB Arduino demo
-	this.endpointOut_ =4;			// original out endpoint ID of WebUSB Arduino demo
-
+    this.interfaceNumber_ = 2;  // original interface number of WebUSB Arduino demo
+    this.endpointIn_ = 5;       // original in endpoint ID of WebUSB Arduino demo
+    this.endpointOut_ = 4;      // original out endpoint ID of WebUSB Arduino demo
   };
 
   serial.Port.prototype.connect = function() {
@@ -52,24 +46,24 @@ var serial = {};
             return this.device_.selectConfiguration(1);
           }
         })
-		.then(()=> {
-			var configurationInterfaces= this.device_.configuration.interfaces;
-			configurationInterfaces.forEach(element => {
-				element.alternates.forEach(elementalt => {
-					if (elementalt.interfaceClass==0xff) {
-						this.interfaceNumber_ = element.interfaceNumber;
-						elementalt.endpoints.forEach(elementendpoint => {
-							if (elementendpoint.direction=="out") {
-								this.endpointOut_ =elementendpoint.endpointNumber;
-							}
-							if (elementendpoint.direction=="in") {
-								this.endpointIn_ =elementendpoint.endpointNumber;
-							}
-						})
-					}
-				})
-			})
-		})
+        .then(() => {
+          var configurationInterfaces = this.device_.configuration.interfaces;
+          configurationInterfaces.forEach(element => {
+            element.alternates.forEach(elementalt => {
+              if (elementalt.interfaceClass==0xff) {
+                this.interfaceNumber_ = element.interfaceNumber;
+                elementalt.endpoints.forEach(elementendpoint => {
+                  if (elementendpoint.direction == "out") {
+                    this.endpointOut_ = elementendpoint.endpointNumber;
+                  }
+                  if (elementendpoint.direction=="in") {
+                    this.endpointIn_ =elementendpoint.endpointNumber;
+                  }
+                })
+              }
+            })
+          })
+        })
         .then(() => this.device_.claimInterface(this.interfaceNumber_))
         .then(() => this.device_.selectAlternateInterface(this.interfaceNumber_, 0))
         .then(() => this.device_.controlTransferOut({


### PR DESCRIPTION
The current `serial.js` assumed all WebUSB device has an interface number of 2, in endpoint of 5 and out endpoint of 4, hard coded.

This is correct if the device is just acting as WebUSB alone. When a device has a few other interfaces, the WebUSB interface might not be on interface number 2.

This pull request will loop through the `this.device_` and detect a class of 0xFF (I can't find any other differentiation for other device interface other than this to guess if the interface is WebUSB), loop through the endpoints and get the correct interface number, ID for in and out endpoints .

Hope this helps.

Cheers
JP