### PR TITLE
fixed port object not destroy after disconnect

### DIFF
--- a/demos/console/console.js
+++ b/demos/console/console.js
@@ -59,7 +59,7 @@
       if (port) {
         port.disconnect();
         connectButton.textContent = 'Connect';
-        port=null;
+        port = null;
       } else {
         serial.requestPort().then(selectedPort => {
           port = selectedPort;

--- a/demos/console/console.js
+++ b/demos/console/console.js
@@ -59,6 +59,7 @@
       if (port) {
         port.disconnect();
         connectButton.textContent = 'Connect';
+        port=null;
       } else {
         serial.requestPort().then(selectedPort => {
           port = selectedPort;


### PR DESCRIPTION
On console example, when a user disconnect the `port`, the `port` object was not deleted like the rgb example https://github.com/webusb/arduino/blob/fab0eca52a6ea813e97607a75270bec1399dc77a/demos/rgb/rgb.js#L50

After disconnected, when user click the `connect` button again, there was an error `The device must be opened first`. This happens because the `port` object was already disconnected and will throw this error when a disconnect is called on a disconnected `port`.

![image](https://user-images.githubusercontent.com/1773147/48526593-5ae1d980-e8dc-11e8-8d35-4898c1dfa1db.png)

No device selection dialog was offered when this happened.

Adding a line `port=null` after `port.disconnect()` just like the the rgb example fixed the error message and a device selection dialog will be offered each time

Hope this helps.

JP