### PR TITLE
Add WebUSB support for newer Arduino MKR and NANO boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,15 @@ WebUSB requires an Arduino model that gives the sketch complete control over the
  * Arduino Leonardo
  * Arduino/Genuino Micro
  * Arduino/Genuino Zero
- * Arduino MKR1000
- * Arduino MKR1010
+ * Arduino/Genuino MKR1000
  * Arduino MKRZero
- * Arduino MKRFox1200
+ * Arduino MKR FOX 1200
+ * Arduino MKR WAN 1300
+ * Arduino MKR GSM 1400
+ * Arduino MKR NB 1500
+ * Arduino MKR WiFi 1010
+ * Arduino MKR Vidor 4000
+ * Arduino NANO 33 IoT
  * Adafruit Feather 32u4
  * Adafruit ItsyBitsy 32u4
 

--- a/demos/serial.js
+++ b/demos/serial.js
@@ -11,15 +11,20 @@ var serial = {};
 
   serial.requestPort = function() {
     const filters = [
-      { 'vendorId': 0x2341, 'productId': 0x8036 },
-      { 'vendorId': 0x2341, 'productId': 0x8037 },
-      { 'vendorId': 0x2341, 'productId': 0x804d },
-      { 'vendorId': 0x2341, 'productId': 0x804e },
-      { 'vendorId': 0x2341, 'productId': 0x804f },
-      { 'vendorId': 0x2341, 'productId': 0x8050 },
-      { 'vendorId': 0x2341, 'productId': 0x8054 },
-      { 'vendorId': 0x239A, 'productId': 0x000E },
-      { 'vendorId': 0x239A, 'productId': 0x800D },
+      { 'vendorId': 0x2341, 'productId': 0x8036 }, // Arduino Leonardo
+      { 'vendorId': 0x2341, 'productId': 0x8037 }, // Arduino Micro
+      { 'vendorId': 0x2341, 'productId': 0x804d }, // Arduino/Genuino Zero
+      { 'vendorId': 0x2341, 'productId': 0x804e }, // Arduino/Genuino MKR1000
+      { 'vendorId': 0x2341, 'productId': 0x804f }, // Arduino MKRZERO
+      { 'vendorId': 0x2341, 'productId': 0x8050 }, // Arduino MKR FOX 1200
+      { 'vendorId': 0x2341, 'productId': 0x8052 }, // Arduino MKR GSM 1400
+      { 'vendorId': 0x2341, 'productId': 0x8053 }, // Arduino MKR WAN 1300
+      { 'vendorId': 0x2341, 'productId': 0x8054 }, // Arduino MKR WiFi 1010
+      { 'vendorId': 0x2341, 'productId': 0x8055 }, // Arduino MKR NB 1500
+      { 'vendorId': 0x2341, 'productId': 0x8056 }, // Arduino MKR Vidor 4000
+      { 'vendorId': 0x2341, 'productId': 0x8057 }, // Arduino NANO 33 IoT
+      { 'vendorId': 0x239A, 'productId': 0x000E }, // Adafruit ItsyBitsy 32u4
+      { 'vendorId': 0x239A, 'productId': 0x800D }, // Adafruit ItsyBitsy 32u4
     ];
     return navigator.usb.requestDevice({ 'filters': filters }).then(
       device => new serial.Port(device)


### PR DESCRIPTION
This commit adds WebUSB support for newer Arduino MKR and NANO boards. Specifically, we are adding:
- Arduino MKR WAN 1300
- Arduino MKR GSM 1400
- Arduino MKR NB 1500
- Arduino MKR WiFi 1010
- Arduino MKR Vidor 4000
- Arduino NANO 33 IoT