### PR TITLE
Fix control transfers on SAMD

### DIFF
--- a/demos/console/sketch/sketch.ino
+++ b/demos/console/sketch/sketch.ino
@@ -10,6 +10,7 @@
  */
 WebUSB WebUSBSerial(1 /* https:// */, "webusb.github.io/arduino/demos/console");
 
+#undef Serial
 #define Serial WebUSBSerial
 
 const int ledPin = 13;

--- a/demos/rgb/sketch/sketch.ino
+++ b/demos/rgb/sketch/sketch.ino
@@ -10,6 +10,7 @@
  */
 WebUSB WebUSBSerial(1 /* https:// */, "webusb.github.io/arduino/demos/rgb");
 
+#undef Serial
 #define Serial WebUSBSerial
 
 const int redPin = 9;

--- a/demos/serial.js
+++ b/demos/serial.js
@@ -70,6 +70,9 @@ var serial = {};
               }
             })
           })
+          console.log(`Interface: ${this.interfaceNumber_}`);
+          console.log(`IN endpoint: ${this.endpointIn_}`);
+          console.log(`OUT endpoint: ${this.endpointOut_}`);
         })
         .then(() => this.device_.claimInterface(this.interfaceNumber_))
         .then(() => this.device_.selectAlternateInterface(this.interfaceNumber_, 0))
@@ -80,6 +83,7 @@ var serial = {};
             'value': 0x01,
             'index': this.interfaceNumber_}))
         .then(() => {
+          console.log('Starting read loop.');
           readLoop();
         });
   };

--- a/library/WebUSB/WebUSB.h
+++ b/library/WebUSB/WebUSB.h
@@ -66,6 +66,7 @@ public:
 	 * URL.
 	 */
 	WebUSB(uint8_t landingPageScheme, const char* landingPageUrl);
+	~WebUSB();
 	void begin(unsigned long);
 	void begin(unsigned long, uint8_t);
 	void end(void);
@@ -132,8 +133,7 @@ private:
 	uint8_t protocol;
 	uint8_t idle;
 	int peek_buffer;
-	uint8_t landingPageScheme;
-	const char* landingPageUrl;
+	uint8_t *landingPageDescriptor;
 	const char* shortName;
 	
 	bool portOpenResult;


### PR DESCRIPTION
On SAMD-based boards it appears that the entire control transfer reply
needs to be passed to USB_SendControl() at once. The original code took
advantage of making multiple calls to construct replies from smaller
chunks. This has been rewritten to construct and send the entire
responce at once.

Fixes #79.